### PR TITLE
Update font_size_dialog.xml

### DIFF
--- a/app/src/main/res/layout/font_size_dialog.xml
+++ b/app/src/main/res/layout/font_size_dialog.xml
@@ -59,7 +59,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="15dp"
         android:layout_marginTop="10dp"
-        android:text="Landscape font size:"
+        android:text="Presentation/Landscape font size:"
         android:textAppearance="@style/TextAppearance.AppCompat.Widget.ActionBar.Title"
         android:textColor="@color/background_material_dark"
         android:textSize="18sp"/>

--- a/app/src/main/res/layout/font_size_dialog.xml
+++ b/app/src/main/res/layout/font_size_dialog.xml
@@ -10,7 +10,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="15dp"
         android:layout_marginTop="10dp"
-        android:text="Portrait font size:"
+        android:text="Font size:"
         android:textAppearance="@style/TextAppearance.AppCompat.Widget.ActionBar.Title"
         android:textColor="@color/background_material_dark"
         android:textSize="18sp"/>
@@ -59,7 +59,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="15dp"
         android:layout_marginTop="10dp"
-        android:text="Presentation/Landscape font size:"
+        android:text="Presentation font size:"
         android:textAppearance="@style/TextAppearance.AppCompat.Widget.ActionBar.Title"
         android:textColor="@color/background_material_dark"
         android:textSize="18sp"/>


### PR DESCRIPTION
The "Landscape font size" changes only the "Presentation font size". The main app view can be used in landscape mode, too! ;-)

"Portrait" suffix deleted from "Portrait font size" since all other views but the "Presentation" view use the "Portrait font size".